### PR TITLE
Update Mergify to use merge rather than rebase

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -64,7 +64,7 @@ pull_request_rules:
       - "-closed"
     actions:
       merge:
-        method: rebase
+        method: merge
 
   # If there is a conflict between this pull request and the default branch, or
   # this pull request has failed behind the default branch due to other pull


### PR DESCRIPTION
Update Mergify to use merge rather than rebase as rebase has been disabled following that it does not protect signed commits even when it does not have to rebase the branch before merging.

## Checklist

Please confirm the following checks:

- [x] My pull request follows the guidelines set out in `CONTRIBUTING.md`.
- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my code and corrected any misspellings.
- [x] Each commit in this pull request has a meaningful subject & body for context.
- [x] I have squashed all "fix(up)" commits to provide a clean code history.
- [x] My pull request has an appropriate title and description for context.
- [ ] I have linked this pull request to other issues or pull requests as needed.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels as needed.
