### PR TITLE
Migrate `tfsec` to `trivy` as `tfsec` is joining Trivy

### DIFF
--- a/{{cookiecutter.repository.name}}/.github/workflows/terraform-integrations.yaml
+++ b/{{cookiecutter.repository.name}}/.github/workflows/terraform-integrations.yaml
@@ -2,9 +2,11 @@
 name: Terraform Integrations
 
 on:
+  # Configure this integration workflow up to be called by other workflows only
+  # (i.e. the terraform-trigger-label and terraform-trigger-pr workflows in this
+  # repository). No inputs are required, as all information about the event will
+  # be pulled in from the context of the event itself
   workflow_call:
-    # No inputs are required, as all information about the event will be pulled
-    # in from the context of the event itself
 
 permissions:
   id-token: write
@@ -16,7 +18,7 @@ permissions:
 jobs:
   module:
     name: Module
-    uses: n3tuk/workflows-reusable/.github/workflows/terraform-checks.yaml@v1.0.0
+    uses: n3tuk/workflows-reusable/.github/workflows/terraform-checks.yaml@v1.2
     secrets: inherit
 {%- if cookiecutter.components.submodules|length > 0 %}
     needs:
@@ -32,7 +34,7 @@ jobs:
 
   submodule-{{ name }}:
     name: Submodule
-    uses: n3tuk/workflows-reusable/.github/workflows/terraform-checks.yaml@v1.0.0
+    uses: n3tuk/workflows-reusable/.github/workflows/terraform-checks.yaml@v1.2
     secrets: inherit
     with:
       working-directory: submodules/{{ name }}
@@ -43,7 +45,7 @@ jobs:
 
   example-{{ name }}:
     name: Example
-    uses: n3tuk/workflows-reusable/.github/workflows/terraform-checks.yaml@v1.0.0
+    uses: n3tuk/workflows-reusable/.github/workflows/terraform-checks.yaml@v1.2
     secrets: inherit
     needs:
       - module
@@ -55,7 +57,7 @@ jobs:
 
   testing:
     name: Testing
-    uses: n3tuk/workflows-reusable/.github/workflows/terraform-tests.yaml@v1.0.0
+    uses: n3tuk/workflows-reusable/.github/workflows/terraform-tests.yaml@v1.2
     secrets: inherit
     needs:
 {%- for name in cookiecutter.components.examples|sort %}

--- a/{{cookiecutter.repository.name}}/.taskfiles/example.yaml
+++ b/{{cookiecutter.repository.name}}/.taskfiles/example.yaml
@@ -30,8 +30,8 @@ tasks:
           test -x "$(which tflint 2>/dev/null)" \
             || (echo "Cannot find 'tflint'. Please install before trying again."; exit 1)
       - cmd: |-
-          test -x "$(which tfsec 2>/dev/null)" \
-            || (echo "Cannot find 'tfsec'. Please install before trying again."; exit 1)
+          test -x "$(which trivy 2>/dev/null)" \
+            || (echo "Cannot find 'trivy'. Please install before trying again."; exit 1)
     status:
       # Setting this file will bypass pre-checks (only use if you are sure)
       - test -f ../../.skip-pre-checks
@@ -44,14 +44,14 @@ tasks:
     deps:
       - task: pre-checks
     sources:
-      - '*.tf'
-      - '../../.terraform-docs.yaml'
-      - '../../.markdownlint.yaml'
+      - "*.tf"
+      - "../../.terraform-docs.yaml"
+      - "../../.markdownlint.yaml"
     cmds:
       - cmd: terraform-docs --config ../../.terraform-docs.yaml .
       - cmd: markdownlint --config ../../.markdownlint.yaml *.md
     generates:
-      - 'README.md'
+      - "README.md"
 
   fmt:
     desc: Reformat the syntax of the Terraform configuration
@@ -60,7 +60,7 @@ tasks:
     deps:
       - task: pre-checks
     sources:
-      - '*.tf'
+      - "*.tf"
     cmds:
       - cmd: terraform fmt -write=true
 
@@ -73,10 +73,10 @@ tasks:
     deps:
       - task: pre-checks
     sources:
-      - '*.tf'
-      - '../../*.tf'
+      - "*.tf"
+      - "../../*.tf"
 {%- if cookiecutter.components.submodules|length > 0 %}
-      - '../../submodules/*/*.tf'
+      - "../../submodules/*/*.tf"
 {%- endif %}
     cmds:
       # Do not attempt to initialise a full backend as well, as this is an
@@ -95,10 +95,10 @@ tasks:
       - task: init
       - task: fmt
     sources:
-      - '*.tf'
-      - '../../*.tf'
+      - "*.tf"
+      - "../../*.tf"
 {%- if cookiecutter.components.submodules|length > 0 %}
-      - '../../submodules/*/*.tf'
+      - "../../submodules/*/*.tf"
 {%- endif %}
     cmds:
       - cmd: terraform validate
@@ -111,8 +111,8 @@ tasks:
     deps:
       - task: validate
     sources:
-      - '../../.tflint.hcl'
-      - '*.tf'
+      - "../../.tflint.hcl"
+      - "*.tf"
     cmds:
       - cmd: tflint --config ../../.tflint.hcl --color --init
       - cmd: tflint --config ../../.tflint.hcl --color
@@ -120,14 +120,15 @@ tasks:
   security:
     desc: Statically analyise the Terraform configuration
     summary: |
-      Run static analysis across the Terraform configuration using tfsec to find
+      Run static analysis across the Terraform configuration using trivy to find
       any bad configurations or potential security issues.
     deps:
       - task: pre-checks
     sources:
-      - '*.tf'
+      - "../../.trivy.yaml"
+      - "*.tf"
     cmds:
-      - cmd: tfsec --concise-output .
+      - cmd: trivy --config ../../.trivy.yaml fs .
 
   clean:
     desc: Remove all temporary files from this Terraform configuration

--- a/{{cookiecutter.repository.name}}/.taskfiles/module.yaml
+++ b/{{cookiecutter.repository.name}}/.taskfiles/module.yaml
@@ -29,8 +29,8 @@ tasks:
           test -x "$(which tflint 2>/dev/null)" \
             || (echo "Cannot find 'tflint'. Please install before trying again."; exit 1)
       - cmd: |-
-          test -x "$(which tfsec 2>/dev/null)" \
-            || (echo "Cannot find 'tfsec'. Please install before trying again."; exit 1)
+          test -x "$(which trivy 2>/dev/null)" \
+            || (echo "Cannot find 'trivy'. Please install before trying again."; exit 1)
     status:
       # Setting this file will bypass pre-checks (only use if you are sure)
       - test -f ../../.skip-pre-checks
@@ -43,14 +43,14 @@ tasks:
     deps:
       - task: pre-checks
     sources:
-      - '*.tf'
-      - '.terraform-docs.yaml'
-      - '.markdownlint.yaml'
+      - "*.tf"
+      - ".terraform-docs.yaml"
+      - ".markdownlint.yaml"
     cmds:
       - cmd: terraform-docs --config .terraform-docs.yaml .
       - cmd: markdownlint --config .markdownlint.yaml *.md
     generates:
-      - 'README.md'
+      - "README.md"
 
   fmt:
     desc: Reformat the syntax of the Terraform module
@@ -59,7 +59,7 @@ tasks:
     deps:
       - task: pre-checks
     sources:
-      - '*.tf'
+      - "*.tf"
     cmds:
       - cmd: terraform fmt -write=true
 
@@ -71,8 +71,8 @@ tasks:
     deps:
       - task: pre-checks
     sources:
-      - '.tflint.hcl'
-      - '*.tf'
+      - ".tflint.hcl"
+      - "*.tf"
     cmds:
       - cmd: tflint --config .tflint.hcl --color --init
       - cmd: tflint --config .tflint.hcl --color
@@ -80,14 +80,15 @@ tasks:
   security:
     desc: Statically analyise the Terraform module
     summary: |
-      Run static analysis across the Terraform module using tfsec to find any bad
+      Run static analysis across the Terraform module using trivy to find any bad
       configurations or potential security issues.
     deps:
       - task: pre-checks
     sources:
-      - '*.tf'
+      - ".trivy.yaml"
+      - "*.tf"
     cmds:
-      - cmd: tfsec --concise-output .
+      - cmd: trivy --config .trivy.yaml fs .
 
   clean:
     desc: Remove all temporary files from this module

--- a/{{cookiecutter.repository.name}}/.taskfiles/submodule.yaml
+++ b/{{cookiecutter.repository.name}}/.taskfiles/submodule.yaml
@@ -29,8 +29,8 @@ tasks:
           test -x "$(which tflint 2>/dev/null)" \
             || (echo "Cannot find 'tflint'. Please install before trying again."; exit 1)
       - cmd: |-
-          test -x "$(which tfsec 2>/dev/null)" \
-            || (echo "Cannot find 'tfsec'. Please install before trying again."; exit 1)
+          test -x "$(which trivy 2>/dev/null)" \
+            || (echo "Cannot find 'trivy'. Please install before trying again."; exit 1)
     status:
       # Setting this file will bypass pre-checks (only use if you are sure)
       - test -f ../../.skip-pre-checks
@@ -43,14 +43,14 @@ tasks:
     deps:
       - task: pre-checks
     sources:
-      - '*.tf'
-      - '../../.terraform-docs.yaml'
-      - '../../.markdownlint.yaml'
+      - "*.tf"
+      - "../../.terraform-docs.yaml"
+      - "../../.markdownlint.yaml"
     cmds:
       - cmd: terraform-docs --config ../../.terraform-docs.yaml .
       - cmd: markdownlint --config ../../.markdownlint.yaml *.md
     generates:
-      - 'README.md'
+      - "README.md"
 
   fmt:
     desc: Reformat the syntax of the Terraform Submodule
@@ -59,7 +59,7 @@ tasks:
     deps:
       - task: pre-checks
     sources:
-      - '*.tf'
+      - "*.tf"
     cmds:
       - cmd: terraform fmt -write=true
 
@@ -69,8 +69,8 @@ tasks:
       Run linting checks against the Submodule to check run-time values,
       such as instance types and naming.
     sources:
-      - '../../.tflint.hcl'
-      - '*.tf'
+      - "../../.tflint.hcl"
+      - "*.tf"
     cmds:
       - cmd: tflint --config ../../.tflint.hcl --color --init
       - cmd: tflint --config ../../.tflint.hcl --color
@@ -78,12 +78,13 @@ tasks:
   security:
     desc: Statically analyise the Terraform Submodule
     summary: |
-      Run static analysis across the Terraform Submodule using tfsec to find any
+      Run static analysis across the Terraform Submodule using trivy to find any
       bad configurations or potential security issues.
     sources:
-      - '*.tf'
+      - "../../.trivy.yaml"
+      - "*.tf"
     cmds:
-      - cmd: tfsec --concise-output .
+      - cmd: trivy --config ../../.trivy.yaml fs .
 
   clean:
     desc: Remove all temporary files from this Submodule

--- a/{{cookiecutter.repository.name}}/.trivy.yaml
+++ b/{{cookiecutter.repository.name}}/.trivy.yaml
@@ -1,0 +1,19 @@
+---
+cache:
+  backend: fs
+format: table
+ignorefile: .trivyignore
+list-all-pkgs: false
+misconfiguration:
+  include-non-failures: false
+  terraform:
+    exclude-downloaded-modules: true
+scan:
+  scanners:
+    - vuln
+    - config
+    - license
+  skip-dirs: []
+  skip-files: []
+  slow: false
+timeout: 5m0s

--- a/{{cookiecutter.repository.name}}/README.md
+++ b/{{cookiecutter.repository.name}}/README.md
@@ -7,6 +7,7 @@ as [`{{ cookiecutter.name }}/{{ cookiecutter.provider }}`][module].
 [n3tuk]: https://github.com/n3tuk
 [tfc]: https://app.terraform.io/app
 [pmr]: https://app.terraform.io/app/n3tuk/registry/private/modules
+
 [module]: https://app.terraform.io/app/n3tuk/registry/modules/private/n3tuk/{{ cookiecutter.name }}/{{ cookiecutter.provider }}
 
 > **Warning**
@@ -63,12 +64,12 @@ This Terraform module uses a set of tools such as [Taskfile (or
 `task`)][taskfile] and [`pre-commit`][pre-commit] to manage this repository
 through development, testing and committing stages, as well as the utility
 [`terraform-docs`][terraform-docs] to automatically manage the documentation,
-and [`tfsec`][tfsec] for static security analysis of the configuration.
+and [`trivy`][trivy] for static security analysis of the configuration.
 
 [taskfile]: https://taskfile.dev/
 [pre-commit]: https://pre-commit.com/
 [terraform-docs]: https://terraform-docs.io/
-[tfsec]: https://github.com/aquasecurity/tfsec
+[trivy]: https://github.com/aquasecurity/trivy
 
 For full details on how to work with this repository and these tools, see the
 [`CONTRIBUTING.md`][contributing-md] document in this repository.

--- a/{{cookiecutter.repository.name}}/Taskfile.yaml
+++ b/{{cookiecutter.repository.name}}/Taskfile.yaml
@@ -128,10 +128,10 @@ tasks:
 {%- endfor %}
 
   security:
-    desc: Run static analysis using tfsec
+    desc: Run static analysis against Terraform
     summary: |
-      Run static analysis across the Terraform module using tfsec to find any
-      bad configurations or potential security issues.
+      Run static analysis across the Terraform module to find any bad
+      configurations or potential security issues.
     cmds:
 {%- for name in cookiecutter.components.submodules|sort %}
       - task: submodules:{{ name }}:security


### PR DESCRIPTION
Following the notice that `tfsec` is joining Trivy, update the `terraform-checks` workflow to use `trivy` instead of `tfsec`.

## Checklist

Please confirm the following checks:

- [x] My pull request follows the guidelines set out in `CONTRIBUTING.md`.
- [ ] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my code and corrected any misspellings.
- [x] Each commit in this pull request has a meaningful subject & body for context.
- [x] I have squashed all "fix(up)" commits to provide a clean code history.
- [x] My pull request has an appropriate title and description for context.
- [ ] I have linked this pull request to other issues or pull requests as needed.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels as needed.
